### PR TITLE
[Task #55] 볼린저 밴드 최소 폭 필터 추가 (장 초반 노이즈 방지)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -33,6 +33,7 @@ class StrategyConfig(BaseModel):
     bollinger_period: int = 20
     bollinger_num_std: float = 2.0
     bollinger_volume_filter: bool = True
+    bollinger_min_bandwidth: float = 1.0  # 밴드 폭 최소 % (장 초반 노이즈 방지)
 
     # 분봉 설정
     use_minute_chart: bool = True
@@ -112,6 +113,7 @@ class TradingConfig(BaseSettings):
     bollinger_num_std: float = 2.0  # 표준편차 배수
     bollinger_volume_filter: bool = True  # 볼린저 매수 시 거래량 필터 적용
     bollinger_volume_ma_period: int = 20  # 거래량 SMA 기간
+    bollinger_min_bandwidth: float = 1.0  # 밴드 폭 최소 % (장 초반 노이즈 방지)
 
     # 단타 제한
     max_daily_trades: int = 5  # 종목당 하루 최대 매수 횟수

--- a/app/trading/engine.py
+++ b/app/trading/engine.py
@@ -436,6 +436,7 @@ class TradingEngine:
                 period=cfg.bollinger_period,
                 num_std=cfg.bollinger_num_std,
                 volume_ma_period=vol_period,
+                min_bandwidth=cfg.bollinger_min_bandwidth,
             )
             logger.info(
                 "[%s] %s | 현재가=%.0f, BB(%.0f/%.0f/%.0f), vol_ok=%s | %s",


### PR DESCRIPTION
## Summary
## 문제
장 시작 직후 분봉 데이터가 적어 볼린저 밴드 폭이 극도로 좁아짐.
(삼성전자: 상단 189,485 ~ 하단 188,614, 폭 0.46%)
→ 작은 가격 변동에도 BUY/SELL 시그널이 과다 발생.

## 작업
1. StrategyConfig에 `bollinger_min_bandwidth: float = 1.0` 추가 (밴드 폭 최소 %)
2. strategy.py bollinger_signal()에서 밴드 폭 체크:
   - bandwidth = (upper - lower) / middle * 100
   - bandwidth < min_bandwidth이면 HOLD 반환 + reason에 "밴드 폭 부족" 기록
3. 장 시작 후 N분(예: 20분) 경과 전에는 분봉 데이터 부족으로 밴드 폭 자연히 좁으므로, 이 필터가 사실상 장 초반 매매 방지 역할

## 파일
- `app/config.py` (StrategyConfig)
- `app/trading/strategy.py` (bollinger_signal)

## 테스트
- test_strategy.py에 밴드 폭 필터 검증 테스트 추가

## Changes
```
app/config.py           |  2 ++
 app/trading/engine.py   |  1 +
 app/trading/strategy.py | 13 +++++++++++++
 tests/test_strategy.py  | 34 ++++++++++++++++++++++++++++++++++
 4 files changed, 50 insertions(+)
```

## Details
| Field | Value |
|-------|-------|
| Priority | High |
| Labels | strategy, feature |
| Epic | #3 매매 로깅 강화 및 매매 근거 추적 |
| Cost | $1.0416 |
| Branch | `feat/task-55-` |

---
🤖 Generated by [Claude Pilot](https://github.com/seonghyeoklee/claude-pilot)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능

* **Bollinger 대역폭 필터링 추가**: 최소 대역폭 미만일 때 거래 신호를 자동으로 보류(HOLD)로 설정하여 초기 장중 노이즈로 인한 거래를 방지합니다.
* **설정 파라미터 추가**: 새로운 `bollinger_min_bandwidth` 설정값을 통해 대역폭 필터링 기준을 조정할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->