### PR TITLE
[Task #56] 일일 저널 리포트에 매매 판단 근거 컬럼 추가

### DIFF
--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -173,13 +173,14 @@ _BODY_HTML = """
             <th style="text-align:left">시각</th>
             <th style="text-align:left">종목</th>
             <th>신호</th>
+            <th style="text-align:left">판단 근거</th>
             <th>가격</th>
             <th>단기MA</th>
             <th>장기MA</th>
           </tr>
         </thead>
         <tbody id="signals-body">
-          <tr><td colspan="6" class="empty-msg">--</td></tr>
+          <tr><td colspan="7" class="empty-msg">--</td></tr>
         </tbody>
       </table>
     </div>
@@ -193,10 +194,11 @@ _BODY_HTML = """
             <th>매수/매도</th>
             <th>수량</th>
             <th>사유</th>
+            <th style="text-align:left">상세</th>
           </tr>
         </thead>
         <tbody id="orders-body">
-          <tr><td colspan="5" class="empty-msg">--</td></tr>
+          <tr><td colspan="6" class="empty-msg">--</td></tr>
         </tbody>
       </table>
     </div>
@@ -287,26 +289,32 @@ function updateStatusUI(data) {
 
 function updateSignalsTable(signals) {
   const tbody = document.getElementById('signals-body');
-  if (!signals.length) { tbody.innerHTML = '<tr><td colspan="6" class="empty-msg">시그널 없음</td></tr>'; return; }
-  tbody.innerHTML = signals.slice(0, 20).map(s => `<tr>
+  if (!signals.length) { tbody.innerHTML = '<tr><td colspan="7" class="empty-msg">시그널 없음</td></tr>'; return; }
+  tbody.innerHTML = signals.slice(0, 20).map(s => {
+    const reason = s.reason_detail || '';
+    const reasonStyle = s.signal === 'HOLD' || !s.signal ? 'color:#64748b' : '';
+    return `<tr>
     <td style="text-align:left">${fmtTime(s.timestamp)}</td>
     <td style="text-align:left">${stockLabel(s.symbol)}</td>
     <td>${signalBadge(s.signal)}</td>
+    <td class="reason-detail" style="text-align:left;${reasonStyle}">${reason}</td>
     <td>${fmt(s.current_price)}</td>
     <td>${fmt(s.short_ma)}</td>
     <td>${fmt(s.long_ma)}</td>
-  </tr>`).join('');
+  </tr>`;
+  }).join('');
 }
 
 function updateOrdersTable(orders) {
   const tbody = document.getElementById('orders-body');
-  if (!orders.length) { tbody.innerHTML = '<tr><td colspan="5" class="empty-msg">주문 없음</td></tr>'; return; }
+  if (!orders.length) { tbody.innerHTML = '<tr><td colspan="6" class="empty-msg">주문 없음</td></tr>'; return; }
   tbody.innerHTML = orders.slice(0, 20).map(o => `<tr>
     <td style="text-align:left">${fmtTime(o.timestamp)}</td>
     <td style="text-align:left">${stockLabel(o.symbol)}</td>
     <td>${o.side === 'buy' ? '<span class="buy-badge">매수</span>' : '<span class="sell-badge">매도</span>'}</td>
     <td>${o.quantity}</td>
     <td>${reasonBadge(o.reason)}</td>
+    <td class="reason-detail" style="text-align:left">${o.reason_detail || ''}</td>
   </tr>`).join('');
 }
 

--- a/app/trading/journal.py
+++ b/app/trading/journal.py
@@ -196,11 +196,15 @@ def _build_report_html(d: date, events: list[TradeEvent]) -> str:
         if s.upper_band is not None:
             bb_str = f"{s.upper_band:.0f}/{s.middle_band:.0f}/{s.lower_band:.0f}"
 
+        reason_str = s.signal_reason or ""
+        reason_style = "color:#64748b" if s.signal in ("HOLD", "") else ""
+
         signal_rows += f"""
         <tr>
             <td>{ts}</td>
             <td>{s.symbol}</td>
             <td><span class="{sig_class}">{s.signal}</span></td>
+            <td class="reason-detail" style="{reason_style}">{reason_str}</td>
             <td>{s.current_price:,.0f}</td>
             <td>{s.short_ma:.0f}</td>
             <td>{s.long_ma:.0f}</td>
@@ -299,11 +303,11 @@ def _build_report_html(d: date, events: list[TradeEvent]) -> str:
         <table>
             <thead>
                 <tr>
-                    <th>시각</th><th>종목</th><th>시그널</th><th>현재가</th>
+                    <th>시각</th><th>종목</th><th>시그널</th><th>판단 근거</th><th>현재가</th>
                     <th>단기MA</th><th>장기MA</th><th>RSI</th><th>거래량</th><th>BB</th>
                 </tr>
             </thead>
-            <tbody>{signal_rows if signal_rows else '<tr><td colspan="9" style="text-align:center;color:#64748b;">시그널 없음</td></tr>'}</tbody>
+            <tbody>{signal_rows if signal_rows else '<tr><td colspan="10" style="text-align:center;color:#64748b;">시그널 없음</td></tr>'}</tbody>
         </table>
     </details>
 </div>"""

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -51,3 +51,21 @@ class TestDashboardHTML:
         html = _html()
         assert "setInterval(fetchStatus, 5000)" in html
         assert "setInterval(fetchPositions, 10000)" in html
+
+    def test_signal_reason_column(self):
+        """시그널 테이블에 판단 근거 헤더 존재"""
+        assert "판단 근거" in _html()
+
+    def test_signal_reason_in_js(self):
+        """JS가 reason_detail 필드를 시그널 테이블에 렌더링"""
+        assert "s.reason_detail" in _html()
+
+    def test_order_reason_detail_column(self):
+        """주문 테이블에 상세 헤더 존재"""
+        html = _html()
+        # 주문 테이블 thead에 상세 컬럼
+        assert "o.reason_detail" in html
+
+    def test_signal_hold_grey_style(self):
+        """HOLD 시그널은 회색 스타일"""
+        assert "color:#64748b" in _html()


### PR DESCRIPTION
## Summary
## 문제
저널 HTML 리포트의 시그널 테이블에 BUY/SELL 이유가 표시되지 않음.
수치(볼린저 밴드값, MA값)는 있지만 "왜 이 판단인지" 한눈에 안 보임.

## 전제
- #52 (reason_detail 필드 추가) 완료 후 작업

## 작업
1. journal.py _build_report_html()의 시그널 테이블에 "판단 근거" 컬럼 추가
2. signal_reason 필드를 테이블에 표시
3. 주문 테이블에도 order_reason_detail 표시
4. 대시보드(dashboard.py)의 시그널 테이블에도 근거 컬럼 추가 (툴팁 또는 별도 컬럼)
5. BUY/SELL 행은 근거 텍스트 강조 표시 (HOLD는 회색)

## 파일
- `app/trading/journal.py` (_build_report_html)
- `app/dashboard.py` (updateSignalsTable, updateOrdersTable)

## 테스트
- test_journal.py에 근거 컬럼 존재 검증
- test_dashboard.py에 근거 표시 검증

## Changes
```
app/dashboard.py        | 20 ++++++++++++++------
 app/trading/journal.py  |  8 ++++++--
 tests/test_dashboard.py | 18 ++++++++++++++++++
 tests/test_journal.py   | 46 ++++++++++++++++++++++++++++++++++++++++++++++
 4 files changed, 84 insertions(+), 8 deletions(-)
```

## Details
| Field | Value |
|-------|-------|
| Priority | Medium |
| Labels | journal, dashboard, feature |
| Epic | #3 매매 로깅 강화 및 매매 근거 추적 |
| Cost | $1.2871 |
| Branch | `feat/task-56-` |

---
🤖 Generated by [Claude Pilot](https://github.com/seonghyeoklee/claude-pilot)